### PR TITLE
Add starting equipment to player inventory in tutorial

### DIFF
--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -34,7 +34,9 @@ public class TutorialItemHandler : PacketHandler<GameSession> {
 
             tutorialItemsInInventory += session.Item.Equips.Gear.Count(x => x.Value.Id == tutorialItemGroup.Key);
 
-            if (tutorialItemsInInventory >= tutorialItemGroup.Count()) {
+            int tutorialItemsToSpawn = tutorialItemGroup.Select(item => item.Count).Sum();
+
+            if (tutorialItemsInInventory >= tutorialItemsToSpawn) {
                 continue;
             }
 
@@ -42,8 +44,9 @@ public class TutorialItemHandler : PacketHandler<GameSession> {
                 continue;
             }
 
-            foreach (var tutorialItem in tutorialItemGroup) {
-                session.Item.Inventory.Add(new Item(itemMetadata, tutorialItem.Rarity));
+            while (tutorialItemsInInventory < tutorialItemsToSpawn) {
+                session.Item.Inventory.Add(new Item(itemMetadata));
+                tutorialItemsInInventory++;
             }
         }
     }

--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -32,7 +32,7 @@ public class TutorialItemHandler : PacketHandler<GameSession> {
 
             if (!session.ItemMetadata.TryGet(tutorialItem.Id, out var itemMetadata)) continue;
 
-            Item item = new(itemMetadata, tutorialItem.Rarity);
+            var item = new Item(itemMetadata, tutorialItem.Rarity);
             session.Item.Inventory.Add(item, true);
         }
     }

--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -13,27 +13,38 @@ public class TutorialItemHandler : PacketHandler<GameSession> {
     public override RecvOp OpCode => RecvOp.RequestTutorialItem;
 
     public override void Handle(GameSession session, IByteReader packet) {
+        if (session.Player.Value.Character.Level > 1) {
+            return;
+        }
+
         var jobTable = session.TableMetadata.JobTable;
 
         var jobCode = session.Player.Value.Character.Job.Code();
 
-        if (!jobTable.Entries.TryGetValue(jobCode, out var jobMetadata)) return;
-        
-        if (session.Field != null && (session.Player.Value.Character.Level > 1 || jobMetadata.Tutorial.StartField != session.Field.MapId)) return;
+        if (!jobTable.Entries.TryGetValue(jobCode, out var jobMetadata)) {
+            return;
+        }
 
-        foreach (var tutorialItem in jobMetadata.Tutorial.StartItem) {
-            var tutorialItemsInInventory = session.Item.Inventory.Find(tutorialItem.Id).Count();
+        if (session.Field != null && jobMetadata.Tutorial.StartField != session.Field.MapId) {
+            return;
+        }
 
-            tutorialItemsInInventory += session.Item.Equips.Gear.Count(x => x.Value.Id == tutorialItem.Id);
+        foreach (IGrouping<int, JobTable.Item> tutorialItemGroup in jobMetadata.Tutorial.StartItem.GroupBy(item => item.Id)) {
+            int tutorialItemsInInventory = session.Item.Inventory.Find(tutorialItemGroup.Key).Count();
 
-            var tutorialItemsToSpawn = jobMetadata.Tutorial.StartItem.Count(x => x.Id == tutorialItem.Id);
+            tutorialItemsInInventory += session.Item.Equips.Gear.Count(x => x.Value.Id == tutorialItemGroup.Key);
 
-            if (tutorialItemsInInventory >= tutorialItemsToSpawn) continue;
+            if (tutorialItemsInInventory >= tutorialItemGroup.Count()) {
+                continue;
+            }
 
-            if (!session.ItemMetadata.TryGet(tutorialItem.Id, out var itemMetadata)) continue;
+            if (!session.ItemMetadata.TryGet(tutorialItemGroup.Key, out var itemMetadata)) {
+                continue;
+            }
 
-            var item = new Item(itemMetadata, tutorialItem.Rarity);
-            session.Item.Inventory.Add(item, true);
+            foreach (var tutorialItem in tutorialItemGroup) {
+                session.Item.Inventory.Add(new Item(itemMetadata, tutorialItem.Rarity));
+            }
         }
     }
 }

--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -27,11 +27,13 @@ public class TutorialItemHandler : PacketHandler<GameSession>
 
         foreach (JobTable.Item tutorialItem in jobMetadata.Tutorial.StartItem)
         {
-            int tutorialItemsCount = session.Item.Inventory.Find(tutorialItem.Id).Count();
+            int tutorialItemsInInventory = session.Item.Inventory.Find(tutorialItem.Id).Count();
 
-            tutorialItemsCount += session.Item.Equips.Gear.Count(x => x.Value.Id == tutorialItem.Id);
+            tutorialItemsInInventory += session.Item.Equips.Gear.Count(x => x.Value.Id == tutorialItem.Id);
 
-            if (tutorialItemsCount >= tutorialItem.Count)
+            int tutorialItemsToSpawn = jobMetadata.Tutorial.StartItem.Count(x => x.Id == tutorialItem.Id);
+
+            if (tutorialItemsInInventory >= tutorialItemsToSpawn)
             {
                 continue;
             }
@@ -41,9 +43,7 @@ public class TutorialItemHandler : PacketHandler<GameSession>
                 continue;
             }
 
-            int countRemaining = tutorialItem.Count - tutorialItemsCount;
-
-            Item item = new(itemMetadata, tutorialItem.Rarity, countRemaining);
+            Item item = new(itemMetadata, tutorialItem.Rarity);
             session.Item.Inventory.Add(item, true);
         }
     }

--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -25,7 +25,7 @@ public class TutorialItemHandler : PacketHandler<GameSession> {
             return;
         }
 
-        if (session.Field != null && jobMetadata.Tutorial.StartField != session.Field.MapId) {
+        if (session.Field == null || jobMetadata.Tutorial.StartField != session.Field.MapId) {
             return;
         }
 

--- a/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TutorialItemHandler.cs
@@ -1,0 +1,41 @@
+using System;
+using Maple2.Model;
+using Maple2.Model.Enum;
+using Maple2.Model.Game;
+using Maple2.Model.Metadata;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.PacketHandlers;
+using Maple2.Server.Game.Session;
+
+namespace Maple2.Server.Game.PacketHandlers;
+
+public class TutorialItemHandler : PacketHandler<GameSession>
+{
+    public override RecvOp OpCode => RecvOp.RequestTutorialItem;
+
+    public override void Handle(GameSession session, IByteReader packet)
+    {
+        JobTable jobTable = session.TableMetadata.JobTable;
+
+        JobCode jobCode = session.Player.Value.Character.Job.Code();
+
+        Console.WriteLine(jobCode);
+
+        if (!jobTable.Entries.TryGetValue(jobCode, out JobTable.Entry? jobMetadata))
+        {
+            return;
+        }
+        
+        foreach (JobTable.Item tutorialItem in jobMetadata.Tutorial.StartItem)
+        {
+            if (!session.ItemMetadata.TryGet(tutorialItem.Id, out ItemMetadata? itemMetadata))
+            {
+                continue;
+            }
+            
+            Item item = new Item(itemMetadata, tutorialItem.Rarity, tutorialItem.Count);
+            session.Item.Inventory.Add(item, true);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `TutorialItemHandler` that spawns the starting equipment belonging to the class of the player, allowing the player to progress beyond the tutorial.