### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,62 @@
+
+[*]
+
+# Microsoft .NET properties
+csharp_indent_braces = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_else = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = none
+csharp_new_line_between_query_expression_clauses = false
+csharp_preferred_modifier_order = public, required, internal, protected, file, new, private, override, static, async, sealed, virtual, extern, abstract, volatile, unsafe, readonly:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_space_after_cast = true
+csharp_style_var_for_built_in_types = false:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+
+# ReSharper properties
+resharper_align_linq_query = true
+resharper_align_multiline_parameter = true
+resharper_allow_comment_after_lbrace = true
+resharper_arguments_skip_single = true
+resharper_blank_lines_after_block_statements = 0
+resharper_blank_lines_around_auto_property = 0
+resharper_blank_lines_around_property = 0
+resharper_braces_for_for = required
+resharper_braces_for_foreach = required_for_multiline_statement
+resharper_braces_for_ifelse = not_required
+resharper_braces_for_lock = not_required
+resharper_braces_for_while = required
+resharper_braces_redundant = false
+resharper_brace_style = end_of_line
+resharper_csharp_blank_lines_around_field = 0
+resharper_csharp_blank_lines_around_invocable = 0
+resharper_csharp_blank_lines_around_region = 0
+resharper_csharp_blank_lines_inside_region = 0
+resharper_csharp_insert_final_newline = true
+resharper_csharp_max_line_length = 359
+resharper_csharp_remove_blank_lines_near_braces_in_code = false
+resharper_csharp_remove_blank_lines_near_braces_in_declarations = false
+resharper_csharp_wrap_before_binary_opsign = true
+resharper_csharp_wrap_ternary_expr_style = wrap_if_long
+resharper_for_other_types = use_var_when_evident
+resharper_instance_members_qualify_declared_in = 
+resharper_outdent_statement_labels = true
+resharper_parentheses_non_obvious_operations = none, bitwise_and, bitwise_exclusive_or, bitwise_inclusive_or, bitwise
+resharper_parentheses_redundancy_style = remove
+resharper_parentheses_same_type_operations = true
+resharper_place_accessor_attribute_on_same_line = false
+resharper_place_expr_accessor_on_single_line = true
+resharper_place_expr_method_on_single_line = true
+resharper_place_expr_property_on_single_line = true
+resharper_place_field_attribute_on_same_line = false
+resharper_place_simple_embedded_statement_on_same_line = true
+resharper_place_simple_initializer_on_single_line = false
+resharper_space_within_single_line_array_initializer_braces = false
+resharper_trailing_comma_in_multiline_lists = true
+resharper_wrap_array_initializer_style = chop_if_long
+resharper_wrap_before_binary_pattern_op = false
+resharper_wrap_object_and_collection_initializer_style = chop_always


### PR DESCRIPTION
The project currently does not have an editorconfig to enforce consistent formatting. In this MR, an editorconfig file was generated using the Rider IDE's project analysis tool, which looks at the formatting style of the project. 